### PR TITLE
Feat/ignore na

### DIFF
--- a/config.py
+++ b/config.py
@@ -47,6 +47,11 @@ DEFAULT_DATA_VALUES = {
     "tag_outcome": False,
 }
 
+# Columns for which NA should be ignored
+IGNORE_NA = [
+    "time_til_outcome"
+]
+
 # JSONschema schema used to validate config files
 CONFIG_FILE_SCHEMA = {
     "type": "object",

--- a/config.py
+++ b/config.py
@@ -48,9 +48,7 @@ DEFAULT_DATA_VALUES = {
 }
 
 # Columns for which NA should be ignored
-IGNORE_NA = [
-    "time_til_outcome"
-]
+IGNORE_NA = ["time_til_outcome"]
 
 # JSONschema schema used to validate config files
 CONFIG_FILE_SCHEMA = {

--- a/lib/data.py
+++ b/lib/data.py
@@ -9,6 +9,7 @@ import config
 from lib.utils import MongoDBQuery, parse_yml_config
 from lib.decorators import is_random
 
+
 class SFDataset:
     """
     Retrieve a signaux faibles dataset.
@@ -105,10 +106,15 @@ class SFDataset:
         cursor = self.__mongo_collection.aggregate(self.mongo_pipeline.to_pipeline())
 
         self.data = self.__cursor_to_df(cursor)
-        
+
         return self
 
-    def prepare_data(self, remove_strong_signals: bool = False, defaults_map: dict = config.DEFAULT_DATA_VALUES, cols_ignore_na: list = config.IGNORE_NA):
+    def prepare_data(
+        self,
+        remove_strong_signals: bool = False,
+        defaults_map: dict = config.DEFAULT_DATA_VALUES,
+        cols_ignore_na: list = config.IGNORE_NA,
+    ):
         """
         Run data preparation operations on the dataset.
         remove_strong_signals drops observations with time_til_outcome <= 0
@@ -120,11 +126,11 @@ class SFDataset:
 
         logging.info("Replacing missing data with default values")
         self._replace_missing_data(defaults_map)
-        
+
         logging.info("Drop observations with missing required fields.")
         cols_defaults = list(defaults_map.keys())
         self._remove_na(cols_defaults, cols_ignore_na)
-        
+
         if remove_strong_signals:
             logging.info("Removing 'strong signals'.")
             self._remove_strong_signals()
@@ -156,16 +162,27 @@ class SFDataset:
                 logging.debug(f"Column {column} not in dataset")
                 continue
 
-    def _remove_na(self, cols_defaults: list = list(config.DEFAULT_DATA_VALUES.keys()), cols_ignore_na: list = config.IGNORE_NA):
+    def _remove_na(
+        self,
+        cols_defaults: list = list(config.DEFAULT_DATA_VALUES.keys()),
+        cols_ignore_na: list = config.IGNORE_NA,
+    ):
         """
         Remove all observations with missing values.
         """
-        logging.info("Removing NAs from dataset. NAs in the following fields will be ignored instead of dropped: {:s}".format(', '.join(cols_ignore_na)))
-        logging.info(f"Number of observations before: {len(self.data.index)}")
         cols_drop_na = set(self.data.columns).difference(
             set(cols_defaults + cols_ignore_na)
         )
-        self.data.dropna(subset=cols_drop_na ,inplace=True)
+        
+        logging.info(
+            "Removing NAs from dataset.\nNAs in the following fields will be ignored instead of dropped: {0:s}\nThe following fields will be dropped if NA is found: {1:s}\nThe following fields have a default value filled in when a NA is found: {2:s}".format(
+                ", ".join(cols_ignore_na),
+                ", ".join(cols_drop_na),
+                ", ".join(cols_defaults)
+            )
+        )
+        logging.info(f"Number of observations before: {len(self.data.index)}")
+        self.data.dropna(subset=cols_drop_na, inplace=True)
         logging.info(f"Number of observations after: {len(self.data.index)}")
 
     def __repr__(self):

--- a/lib/data.py
+++ b/lib/data.py
@@ -173,7 +173,7 @@ class SFDataset:
                 logging.debug(f"Column {column} not in dataset")
                 continue
 
-    def _remove_na(self, cols_ignore_na):
+    def _remove_na(self, cols_ignore_na: list):
         """
         Remove all observations with missing values.
         """

--- a/lib/data.py
+++ b/lib/data.py
@@ -128,8 +128,7 @@ class SFDataset:
         self._replace_missing_data(defaults_map)
 
         logging.info("Drop observations with missing required fields.")
-        cols_defaults = list(defaults_map.keys())
-        self._remove_na(cols_defaults, cols_ignore_na)
+        self._remove_na(cols_ignore_na)
 
         if remove_strong_signals:
             logging.info("Removing 'strong signals'.")
@@ -155,6 +154,11 @@ class SFDataset:
         Args:
             defaults_map: a dictionnary in the {column_name: default_value} format
         """
+        logging.info(
+            "The following columns will have their missing values mapped to a default: {0:s}".format(
+                ", ".join(list(set(defaults_map.keys())))
+            )
+        )
         for column in defaults_map:
             try:
                 self.data[column] = self.data[column].fillna(defaults_map.get(column))
@@ -164,21 +168,19 @@ class SFDataset:
 
     def _remove_na(
         self,
-        cols_defaults: list = list(config.DEFAULT_DATA_VALUES.keys()),
         cols_ignore_na: list = config.IGNORE_NA,
     ):
         """
         Remove all observations with missing values.
         """
         cols_drop_na = set(self.data.columns).difference(
-            set(cols_defaults + cols_ignore_na)
+            set(cols_ignore_na)
         )
         
         logging.info(
-            "Removing NAs from dataset.\nNAs in the following fields will be ignored instead of dropped: {0:s}\nThe following fields will be dropped if NA is found: {1:s}\nThe following fields have a default value filled in when a NA is found: {2:s}".format(
+            "Removing NAs from dataset.\nNAs in the following fields will be ignored instead of dropped: {0:s}\nThe following fields will be dropped if NA is found, unless default values were specified: {1:s}".format(
                 ", ".join(cols_ignore_na),
                 ", ".join(cols_drop_na),
-                ", ".join(cols_defaults)
             )
         )
         logging.info(f"Number of observations before: {len(self.data.index)}")

--- a/lib/data.py
+++ b/lib/data.py
@@ -163,11 +163,9 @@ class SFDataset:
         if defaults_map is None:
             defaults_map = config.DEFAULT_DATA_VALUES
 
-        logging.info(
-            "The following columns will have their missing values mapped to a default: {0:s}".format(  # pylint: disable=C0301
-                ", ".join(list(set(defaults_map.keys())))
-            )
-        )
+        for feature, default_value in defaults_map.items():
+            logging.debug(f"Column {feature} defaulting to value {default_value}")
+
         for column in defaults_map:
             try:
                 self.data[column] = self.data[column].fillna(defaults_map.get(column))
@@ -175,21 +173,22 @@ class SFDataset:
                 logging.debug(f"Column {column} not in dataset")
                 continue
 
-    def _remove_na(self, cols_ignore_na: list = None):
+    def _remove_na(self, cols_ignore_na):
         """
         Remove all observations with missing values.
         """
-        if cols_ignore_na is None:
-            cols_ignore_na = config.IGNORE_NA
 
         cols_drop_na = set(self.data.columns).difference(set(cols_ignore_na))
 
-        logging.info(
-            "Removing NAs from dataset.\nNAs in the following fields will be ignored instead of dropped: {0:s}\nThe following fields will be dropped if NA is found, unless default values were specified: {1:s}".format(  # pylint: disable=C0301,C0303
-                ", ".join(cols_ignore_na),
-                ", ".join(cols_drop_na),
+        logging.info("Removing NAs from dataset.")
+        for feature in cols_drop_na:
+            logging.debug(
+                f"Rows with NAs in field {feature} will be dropped, unless default val is provided"
             )
-        )
+
+        for feature in cols_ignore_na:
+            logging.debug(f"Rows with NAs in field {feature} will NOT be dropped")
+
         logging.info(f"Number of observations before: {len(self.data.index)}")
         self.data.dropna(subset=cols_drop_na, inplace=True)
         logging.info(f"Number of observations after: {len(self.data.index)}")

--- a/tests/unit/data_test.py
+++ b/tests/unit/data_test.py
@@ -34,13 +34,27 @@ def fake_testing_dataset():
     return dataset
 
 
-def test_drop_na(fake_testing_dataset):
+def test_full_drop_na(fake_testing_dataset):
     """
     must drop 11 (9 in my_feature, 2 other in time_til_outcome)
     """
-    fake_testing_dataset._remove_na()
+    fake_testing_dataset._remove_na(cols_defaults=[], cols_ignore_na=[])
     assert len(fake_testing_dataset) == 9
+    
+def test_part_drop_na(fake_testing_dataset):
+    """
+    must drop 9 (9 in my_feature, nothing from time_til_outcome, as the field is in cols_ignore_na)
+    """
+    fake_testing_dataset._remove_na(cols_defaults=[], cols_ignore_na=["time_til_outcome"])
+    assert len(fake_testing_dataset) == 11
 
+def test_fill_defaults_and_drop_na(fake_testing_dataset):
+    """
+    must replace 9 (None->0 for my_feature) and drop 2 (from time_til_outcome)
+    """
+    fake_testing_dataset._replace_missing_data(defaults_map={"my_feature": 0})
+    fake_testing_dataset._remove_na(cols_ignore_na=[])
+    assert len(fake_testing_dataset) == 18
 
 def test_remove_strong_signals(fake_testing_dataset):
     """
@@ -55,7 +69,7 @@ def test_prepare_data(fake_testing_dataset):
     must drop 11 (NAs) and then 5 more (strong signals)
     must reset index
     """
-    fake_testing_dataset.prepare_data()
+    fake_testing_dataset.prepare_data(cols_ignore_na=[])
     assert len(fake_testing_dataset) == 9
     fake_testing_dataset.prepare_data(remove_strong_signals=True)
     assert len(fake_testing_dataset) == 4

--- a/tests/unit/data_test.py
+++ b/tests/unit/data_test.py
@@ -40,13 +40,15 @@ def test_full_drop_na(fake_testing_dataset):
     """
     fake_testing_dataset._remove_na(cols_ignore_na=[])
     assert len(fake_testing_dataset) == 9
-    
+
+
 def test_part_drop_na(fake_testing_dataset):
     """
     must drop 9 (9 in my_feature, nothing from time_til_outcome, as the field is in cols_ignore_na)
     """
     fake_testing_dataset._remove_na(cols_ignore_na=["time_til_outcome"])
     assert len(fake_testing_dataset) == 11
+
 
 def test_fill_defaults_and_drop_na(fake_testing_dataset):
     """
@@ -55,6 +57,7 @@ def test_fill_defaults_and_drop_na(fake_testing_dataset):
     fake_testing_dataset._replace_missing_data(defaults_map={"my_feature": 0})
     fake_testing_dataset._remove_na(cols_ignore_na=[])
     assert len(fake_testing_dataset) == 18
+
 
 def test_remove_strong_signals(fake_testing_dataset):
     """

--- a/tests/unit/data_test.py
+++ b/tests/unit/data_test.py
@@ -38,14 +38,14 @@ def test_full_drop_na(fake_testing_dataset):
     """
     must drop 11 (9 in my_feature, 2 other in time_til_outcome)
     """
-    fake_testing_dataset._remove_na(cols_defaults=[], cols_ignore_na=[])
+    fake_testing_dataset._remove_na(cols_ignore_na=[])
     assert len(fake_testing_dataset) == 9
     
 def test_part_drop_na(fake_testing_dataset):
     """
     must drop 9 (9 in my_feature, nothing from time_til_outcome, as the field is in cols_ignore_na)
     """
-    fake_testing_dataset._remove_na(cols_defaults=[], cols_ignore_na=["time_til_outcome"])
+    fake_testing_dataset._remove_na(cols_ignore_na=["time_til_outcome"])
     assert len(fake_testing_dataset) == 11
 
 def test_fill_defaults_and_drop_na(fake_testing_dataset):


### PR DESCRIPTION
Closes #14 

As a data scientist, I can now customize list IGNORE_NA within config.py, to include any field for which I wish NAs to be ignored, instead of the data entry being dropped. These columns can also be specified as hoc through novel argument cols_ignore_na of Modified SFDataset.prepare_data(), which defaults to config.IGNORE_NA
Logging registers the columns which will be dropped, and those that will be kept upon meeting NAs.