### PR TITLE
Refacto/remove batch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,3 @@ MONGO_URL=mongodb://your_mongo_url
 MONGO_DB=the_name_of_thedb
 MONGO_COLLECTION=my_awesome_data
 MIN_EFFECTIF=10
-BATCH_ID=2021_happy_new_year

--- a/models/GAM/model.yml
+++ b/models/GAM/model.yml
@@ -11,7 +11,6 @@ features:
   - ratio_dette
   - ratio_dette_moy12m
   - exportation_past_2
-batch_id: "2009_5"
 train_on:
   start_date: "2015-01-01"
   end_date: "2018-06-30"

--- a/predictsignauxfaibles/config.py
+++ b/predictsignauxfaibles/config.py
@@ -20,7 +20,6 @@ MONGODB_PARAMS = MongoParams(
 
 # Other parameters (maybe group them into coherent groups one day...)
 MIN_EFFECTIF = int(os.getenv("MIN_EFFECTIF"))
-BATCH_ID = os.getenv("BATCH_ID")
 
 # Default values for data
 DEFAULT_DATA_VALUES = {

--- a/predictsignauxfaibles/data.py
+++ b/predictsignauxfaibles/data.py
@@ -20,7 +20,6 @@ class SFDataset:
         sample_size: max number of (siret x period) rows to retrieve. Default is all.
         sirets: a list of SIRET to select.
         outcome: restrict query to firms that fall in a specific outcome (True / False)
-        batch_id : MongoDB batch id (defaults to your .env)
         min_effectif: min number of employees for firm to be in the sample (defaults to your .env)
 
     """
@@ -31,7 +30,6 @@ class SFDataset:
         date_max: str = "3000-01-01",
         fields: List = None,
         sample_size: int = 0,  # a sample size of 0 means all data is retrieved
-        batch_id: str = "default",
         min_effectif: int = "default",
         sirets: List = None,
         sirens: List = None,
@@ -49,7 +47,6 @@ class SFDataset:
         self.date_max = date_max
         self.fields = fields
         self.sample_size = sample_size
-        self.batch_id = config.BATCH_ID if batch_id == "default" else batch_id
         self.min_effectif = (
             config.MIN_EFFECTIF if min_effectif == "default" else min_effectif
         )
@@ -74,7 +71,6 @@ class SFDataset:
             date_max=conf[f"{mode}_on"]["end_date"],
             fields=conf["features"] + [conf["target"]] + ["siret", "periode"],
             sample_size=conf[f"{mode}_on"].get("sample_size", 0),
-            batch_id=conf["batch_id"],
         )
 
     def fetch_data(self, warn: bool = True):
@@ -94,7 +90,6 @@ class SFDataset:
             self.date_min,
             self.date_max,
             self.min_effectif,
-            self.batch_id,
             sirets=self.sirets,
             sirens=self.sirens,
             outcome=self.outcome,
@@ -198,7 +193,7 @@ class SFDataset:
 
     def __repr__(self):
         out = f"""
-Signaux Faibles Dataset (batch_id : {self.batch_id})
+Signaux Faibles Dataset
 ----------------------------------------------------
 {self.data.head() if isinstance(self.data, pd.DataFrame) else "Empty Dataset"}
 [...]

--- a/predictsignauxfaibles/utils.py
+++ b/predictsignauxfaibles/utils.py
@@ -35,7 +35,6 @@ class MongoDBQuery:
         date_min: str,
         date_max: str,
         min_effectif: int,
-        batch: str,
         sirets: List = None,
         sirens: List = None,
         outcome: List = None,
@@ -46,12 +45,10 @@ class MongoDBQuery:
             date_min: first period to include, in the 'YYYY-MM-DD' format
             date_max: first period to exclude, in the 'YYYY-MM-DD' format
             min_effectif: the minimum number of employees a firm must have to be included
-            batch: batch_id of the dataset to retrieve
         """
         self.match_stage = {
             "$match": {
                 "$and": [
-                    {"_id.batch": batch},
                     {
                         "_id.periode": {
                             "$gte": self.__date_to_iso(date_min),
@@ -156,7 +153,6 @@ CONFIG_FILE_SCHEMA = {
         "version": {"type": "string"},
         "target": {"type": "string"},
         "features": {"type": "array"},
-        "batch_id": {"type": "string"},
         "train_on": {
             "type": "object",
             "properties": {
@@ -173,7 +169,6 @@ CONFIG_FILE_SCHEMA = {
         "version",
         "target",
         "features",
-        "batch_id",
         "train_on",
         "predict_on",
     ],

--- a/predictsignauxfaibles/utils.py
+++ b/predictsignauxfaibles/utils.py
@@ -68,6 +68,10 @@ class MongoDBQuery:
 
         if outcome is not None:
             self.match_stage["$match"]["$and"].append({"value.outcome": outcome})
+        else:
+            self.match_stage["$match"]["$and"].append(
+                {"value.outcome": {"$in": [True, False]}}
+            )
 
         self.pipeline.append(self.match_stage)
 

--- a/tests/fake_data/correct.yml
+++ b/tests/fake_data/correct.yml
@@ -11,7 +11,6 @@ features:
   - ratio_dette
   - ratio_dette_moy12m
   - exportation_past_2
-batch_id: "2009_5"
 train_on:
   start_date: "2015-01-01"
   end_date: "2018-06-30"

--- a/tests/fake_data/missing_entry.yml
+++ b/tests/fake_data/missing_entry.yml
@@ -1,7 +1,6 @@
 ---
 version: 1.0.0
 target: outcome
-batch_id: "2009_5"
 train_on:
   start_date: "2015-01-01"
   end_date: "2018-06-30"

--- a/tests/unit/data_test.py
+++ b/tests/unit/data_test.py
@@ -9,16 +9,6 @@ from predictsignauxfaibles.data import SFDataset
 import predictsignauxfaibles.config as config
 
 
-def test_dataset_init_default_batch_id():
-    dataset = SFDataset()
-    assert dataset.batch_id == config.BATCH_ID
-
-
-def test_dataset_init_explicit_batch_id():
-    dataset = SFDataset(batch_id="2021_happy_new_year")
-    assert dataset.batch_id == "2021_happy_new_year"
-
-
 @pytest.fixture
 def fake_testing_dataset():
     fake_dta = pd.DataFrame(

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -17,7 +17,6 @@ def test_match_pipeline():
         date_min="1999-12-13",
         date_max="2021-12-10",
         min_effectif=10,
-        batch="2012",
         sirets=["123456789", "123451234"],
     )
     pipeline = query.to_pipeline()
@@ -31,7 +30,6 @@ def test_full_query():
         date_min="1999-12-13",
         date_max="2021-12-10",
         min_effectif=10,
-        batch="2012",
         sirets=["123456789", "123451234"],
     )
     query.add_sort()


### PR DESCRIPTION
This PR removes `batch_id` from the fields needed to query our database.
TODO: re-run the demo notebook

## Problem
Querying the database without explicitly mentioning `batch_id` results in a VERY long query time (so long I had to stop the query manually). I suspect that this is due to a composite index in our database that is not used anymore:
<img width="1002" alt="Screenshot 2021-03-08 at 14 57 17" src="https://user-images.githubusercontent.com/30295971/110331943-053b1900-8020-11eb-825c-907e9a7296a9.png">

