### PR TITLE
refacto: preprocessing

### DIFF
--- a/predictsignauxfaibles/pipelines.py
+++ b/predictsignauxfaibles/pipelines.py
@@ -1,0 +1,89 @@
+from collections import namedtuple
+import logging
+from typing import List
+import pandas as pd
+
+from predictsignauxfaibles.preprocessors import (
+    Preprocessor,
+    remove_administrations,
+    paydex_make_groups,
+    paydex_make_yoy,
+    acoss_make_avg_delta_dette_par_effectif,
+)
+
+
+class MissingDataError(Exception):
+    """
+    Custom error type for `run_pipeline`
+    """
+
+
+def run_pipeline(data: pd.DataFrame, pipeline: List[namedtuple]):
+    """
+    Run a pipeline of Preprocessor objects on a dataframe
+    """
+    logging.info("Checking that input columns are all there.")
+    for preprocessor in pipeline:
+        if not set(preprocessor.input).issubset(data.columns):
+            missing_cols = set(preprocessor.input) - set(data.columns)
+            error_message = (
+                f"Missing variables {missing_cols} in order to run {preprocessor.name}."
+            )
+            raise MissingDataError(error_message)
+
+    logging.info("Running pipeline on data.")
+    data = data.copy()
+    for i, preprocessor in enumerate(pipeline):
+        logging.info(f"STEP {i+1}: {preprocessor.name}")
+        data = preprocessor.function(data)
+        if preprocessor.output is None:
+            continue
+        if not set(preprocessor.output).issubset(data.columns):
+            missing_output_cols = set(preprocessor.output) - set(data.columns)
+            warning_message = f"STEP {i+1}: function {preprocessor.function.__name__} \
+did not produce expected output {missing_output_cols}"
+            logging.warning(warning_message)
+            continue
+
+    return data
+
+
+# Pipelines
+
+DEFAULT_PIPELINE = [
+    Preprocessor(
+        "Remove Administrations",
+        function=remove_administrations,
+        input=["code_naf"],
+        output=None,
+    ),
+    Preprocessor(
+        "Make `paydex_yoy`",
+        function=paydex_make_yoy,
+        input=["paydex_nb_jours", "paydex_nb_jours_past_12"],
+        output=["paydex_yoy"],
+    ),
+    Preprocessor(
+        "Make `paydex_group`",
+        function=paydex_make_groups,
+        input=["paydex_nb_jours"],
+        output=["paydex_group"],
+    ),
+    Preprocessor(
+        "Make `avg_delta_dette_par_effectif`",
+        acoss_make_avg_delta_dette_par_effectif,
+        input=[
+            "effectif",
+            "montant_part_patronale",
+            "montant_part_ouvriere",
+            "montant_part_patronale_past_3",
+            "montant_part_ouvriere_past_3",
+        ],
+        output=["avg_delta_dette_par_effectif"],
+    ),
+]
+
+# This is useful for automatic testing
+ALL_PIPELINES = [
+    DEFAULT_PIPELINE,
+]

--- a/predictsignauxfaibles/preprocessors.py
+++ b/predictsignauxfaibles/preprocessors.py
@@ -25,7 +25,7 @@ def paydex_make_groups(data: pd.DataFrame):
     Cut paydex into bins
     """
     data["paydex_group"] = pd.cut(
-        data["paydex_nb_jours"], bins=(-float("inf"), 15, 30, 60, 90, float("inf"))
+        data["paydex_nb_jours"], bins=(-float("inf"), 0, 15, 30, 60, 90, float("inf"))
     )
     return data
 

--- a/predictsignauxfaibles/preprocessors.py
+++ b/predictsignauxfaibles/preprocessors.py
@@ -56,6 +56,7 @@ def paydex_make_yoy(data: pd.DataFrame):
     """
     TODO: this should be in opensignauxfaibles/reducejs2
     Compute a new column for the dataset containing the year-over-year
+    Output column : 'paydex_yoy'
     """
     data["paydex_yoy"] = data["paydex_nb_jours"] - data["paydex_nb_jours_past_12"]
     return data
@@ -64,6 +65,7 @@ def paydex_make_yoy(data: pd.DataFrame):
 def paydex_make_groups(data: pd.DataFrame):
     """
     Cut paydex into bins
+    Output column : 'paydex_group'
     """
     data["paydex_group"] = pd.cut(
         data["paydex_nb_jours"], bins=(-float("inf"), 0, 15, 30, 60, 90, float("inf"))
@@ -74,6 +76,7 @@ def paydex_make_groups(data: pd.DataFrame):
 def acoss_make_avg_delta_dette_par_effectif(data: pd.DataFrame):
     """
     Compute the average change in social debt / effectif
+    Output column : 'avg_delta_dette_par_effectif'
     """
 
     data["dette_par_effectif"] = (

--- a/predictsignauxfaibles/preprocessors.py
+++ b/predictsignauxfaibles/preprocessors.py
@@ -5,6 +5,8 @@ from typing import List
 import numpy as np
 import pandas as pd
 
+Preprocessor = namedtuple("Preprocessor", ["name", "function", "input", "output"])
+
 
 class MissingDataError(Exception):
     """
@@ -92,8 +94,6 @@ def acoss_make_avg_delta_dette_par_effectif(data: pd.DataFrame):
     data.drop(columns=columns_to_drop, axis=1, inplace=True)
     return data
 
-
-Preprocessor = namedtuple("Preprocessor", ["name", "function", "input", "output"])
 
 PIPELINE = [
     Preprocessor(

--- a/predictsignauxfaibles/preprocessors.py
+++ b/predictsignauxfaibles/preprocessors.py
@@ -1,47 +1,9 @@
 from collections import namedtuple
-import logging
-from typing import List
 
 import numpy as np
 import pandas as pd
 
 Preprocessor = namedtuple("Preprocessor", ["name", "function", "input", "output"])
-
-
-class MissingDataError(Exception):
-    """
-    Custom error type for `run_pipeline`
-    """
-
-
-def run_pipeline(data: pd.DataFrame, pipeline: List[namedtuple]):
-    """
-    Run a pipeline of Preprocessor objects on a dataframe
-    """
-    logging.info("Checking that input columns are all there.")
-    for preprocessor in pipeline:
-        if not set(preprocessor.input).issubset(data.columns):
-            missing_cols = set(preprocessor.input) - set(data.columns)
-            error_message = (
-                f"Missing variables {missing_cols} in order to run {preprocessor.name}."
-            )
-            raise MissingDataError(error_message)
-
-    logging.info("Running pipeline on data.")
-    data = data.copy()
-    for i, preprocessor in enumerate(pipeline):
-        logging.info(f"STEP {i+1}: {preprocessor.name}")
-        data = preprocessor.function(data)
-        if preprocessor.output is None:
-            continue
-        if not set(preprocessor.output).issubset(data.columns):
-            missing_output_cols = set(preprocessor.output) - set(data.columns)
-            warning_message = f"STEP {i+1}: function {preprocessor.function.__name__} \
-did not produce expected output {missing_output_cols}"
-            logging.warning(warning_message)
-            continue
-
-    return data
 
 
 def remove_administrations(data: pd.DataFrame):
@@ -96,37 +58,3 @@ def acoss_make_avg_delta_dette_par_effectif(data: pd.DataFrame):
     columns_to_drop = ["dette_par_effectif", "dette_par_effectif_past_3"]
     data.drop(columns=columns_to_drop, axis=1, inplace=True)
     return data
-
-
-PIPELINE = [
-    Preprocessor(
-        "Remove Administrations",
-        function=remove_administrations,
-        input=["code_naf"],
-        output=None,
-    ),
-    Preprocessor(
-        "Make `paydex_yoy`",
-        function=paydex_make_yoy,
-        input=["paydex_nb_jours", "paydex_nb_jours_past_12"],
-        output=["paydex_yoy"],
-    ),
-    Preprocessor(
-        "Make `paydex_group`",
-        function=paydex_make_groups,
-        input=["paydex_nb_jours"],
-        output=["paydex_group"],
-    ),
-    Preprocessor(
-        "Make `avg_delta_dette_par_effectif`",
-        acoss_make_avg_delta_dette_par_effectif,
-        input=[
-            "effectif",
-            "montant_part_patronale",
-            "montant_part_ouvriere",
-            "montant_part_patronale_past_3",
-            "montant_part_ouvriere_past_3",
-        ],
-        output=["avg_delta_dette_par_effectif"],
-    ),
-]

--- a/predictsignauxfaibles/preprocessors.py
+++ b/predictsignauxfaibles/preprocessors.py
@@ -1,0 +1,44 @@
+from collections import namedtuple
+import pandas as pd
+
+
+def remove_administrations(data: pd.DataFrame):
+    """
+    Remove observations with NAF Code 'O' (administrations) or 'P' education
+    """
+    data = data.query("code_naf != 'O' and code_naf != 'P'")
+    return data
+
+
+def paydex_make_yoy(data: pd.DataFrame):
+    """
+    TODO: this should be in opensignauxfaibles/reducejs2
+    Compute a new column for the dataset containing the year-over-year
+    """
+    data["paydex_yoy"] = data["paydex_nb_jours"] - data["paydex_nb_jours_past_12"]
+    return data
+
+
+def paydex_make_groups(data: pd.DataFrame):
+    """
+    Cut paydex into bins
+    """
+    data["paydex_group"] = pd.cut(
+        data["paydex_nb_jours"], bins=(-float("inf"), 15, 30, 60, 90, float("inf"))
+    )
+    return data
+
+
+Preprocessor = namedtuple("Preprocessor", ["function", "input", "output"])
+
+PIPELINE = [
+    Preprocessor(remove_administrations, input=["code_naf"], output=None),
+    Preprocessor(
+        paydex_make_yoy,
+        input=["paydex_nb_jours", "paydex_nb_jours_past_12"],
+        output=["paydex_yoy"],
+    ),
+    Preprocessor(
+        paydex_make_groups, input=["paydex_nb_jours"], output=["paydex_group"]
+    ),
+]

--- a/tests/fake_data/dataframes.py
+++ b/tests/fake_data/dataframes.py
@@ -18,3 +18,11 @@ df_test_paydex = pd.DataFrame(
         "paydex_nb_jours_past_12": [91, 30, 15],
     }
 )
+
+df_test_code_naf = pd.DataFrame(
+    {
+        "code_naf": ["A", "B", "E", "O", "P"],
+    }
+)
+
+df_test_full = pd.concat((df_test_code_naf, df_test_acoss, df_test_paydex), axis=1)

--- a/tests/fake_data/dataframes.py
+++ b/tests/fake_data/dataframes.py
@@ -1,0 +1,13 @@
+import pandas as pd
+
+df_test_acoss = pd.DataFrame(
+    {
+        "effectif": [10, 10, 10_000],
+        # part sociale
+        "montant_part_patronale": [1_000, 1_200, 0],
+        "montant_part_patronale_past_3": [1_000, 0, 1_200],
+        # part ouvriere
+        "montant_part_ouvriere": [0, 300, 1_200],
+        "montant_part_ouvriere_past_3": [0, 0, 1_200],
+    }
+)

--- a/tests/fake_data/dataframes.py
+++ b/tests/fake_data/dataframes.py
@@ -11,3 +11,10 @@ df_test_acoss = pd.DataFrame(
         "montant_part_ouvriere_past_3": [0, 0, 1_200],
     }
 )
+
+df_test_paydex = pd.DataFrame(
+    {
+        "paydex_nb_jours": [10, 30, 10_000],
+        "paydex_nb_jours_past_12": [91, 30, 15],
+    }
+)

--- a/tests/unit/pipelines_test.py
+++ b/tests/unit/pipelines_test.py
@@ -1,0 +1,53 @@
+# pylint: disable=missing-function-docstring
+import pandas as pd
+import pytest
+
+from predictsignauxfaibles.pipelines import (
+    ALL_PIPELINES,
+    DEFAULT_PIPELINE,
+    run_pipeline,
+    MissingDataError,
+)
+
+from predictsignauxfaibles.preprocessors import Preprocessor
+
+from tests.fake_data.dataframes import (
+    df_test_acoss,
+    df_test_paydex,
+    df_test_full,
+    df_test_code_naf,
+)
+
+
+@pytest.mark.parametrize("pipeline", ALL_PIPELINES)
+def test_final_pipeline(pipeline):
+    for preprocessor in pipeline:
+        assert isinstance(preprocessor, Preprocessor)
+        assert hasattr(preprocessor, "name")
+        assert hasattr(preprocessor, "function")
+        assert hasattr(preprocessor, "input")
+        assert hasattr(preprocessor, "output")
+        assert isinstance(preprocessor.name, str)
+        assert callable(preprocessor.function)
+        assert isinstance(preprocessor.input, list)
+        assert isinstance(preprocessor.output, list) or preprocessor.output is None
+
+
+def test_default_pipeline_sucess():
+    data_in = df_test_full.copy()
+    data_out = run_pipeline(data_in, pipeline=DEFAULT_PIPELINE)
+    assert data_out.shape == (3, 11)
+    # acoss
+    assert (data_out["avg_delta_dette_par_effectif"] == [0, 50, -0.04]).all()
+    # paydex yoy
+    assert (data_out["paydex_yoy"] == [-81, 0, 9_985]).all()
+    # paydex group
+    expected = [pd.Interval(0, 15), pd.Interval(15, 30), pd.Interval(90, float("inf"))]
+    assert (data_out["paydex_group"] == expected).all()
+
+
+def test_default_pipeline_missing_input():
+    data_in = df_test_full.copy()
+    data_in.drop(columns=("code_naf"), inplace=True)
+    with pytest.raises(MissingDataError):
+        run_pipeline(data_in, pipeline=DEFAULT_PIPELINE)

--- a/tests/unit/preprocessors_test.py
+++ b/tests/unit/preprocessors_test.py
@@ -1,5 +1,11 @@
 # pylint: disable=missing-function-docstring
-from predictsignauxfaibles.preprocessors import PIPELINE, Preprocessor
+from predictsignauxfaibles.preprocessors import (
+    PIPELINE,
+    Preprocessor,
+    acoss_make_avg_delta_dette_par_effectif,
+)
+
+from tests.fake_data.dataframes import df_test_acoss
 
 
 def test_final_pipeline():
@@ -10,3 +16,10 @@ def test_final_pipeline():
         assert hasattr(preprocessor, "output")
         assert isinstance(preprocessor.input, list)
         assert isinstance(preprocessor.output, list) or preprocessor.output is None
+
+
+def test_acoss_make_avg_delta_dette_par_effectif():
+    data_in = df_test_acoss.copy()
+    data_out = acoss_make_avg_delta_dette_par_effectif(data_in)
+    assert (data_out["avg_delta_dette_par_effectif"] == (0, 50, -0.04)).all()
+    assert len(data_out.columns) == len(df_test_acoss.columns) + 1

--- a/tests/unit/preprocessors_test.py
+++ b/tests/unit/preprocessors_test.py
@@ -7,11 +7,17 @@ from predictsignauxfaibles.preprocessors import (
     acoss_make_avg_delta_dette_par_effectif,
     paydex_make_groups,
     paydex_make_yoy,
+    remove_administrations,
     run_pipeline,
     MissingDataError,
 )
 
-from tests.fake_data.dataframes import df_test_acoss, df_test_paydex, df_test_full
+from tests.fake_data.dataframes import (
+    df_test_acoss,
+    df_test_paydex,
+    df_test_full,
+    df_test_code_naf,
+)
 
 
 def test_final_pipeline():
@@ -30,14 +36,14 @@ def test_final_pipeline():
 def test_acoss_make_avg_delta_dette_par_effectif():
     data_in = df_test_acoss.copy()
     data_out = acoss_make_avg_delta_dette_par_effectif(data_in)
-    assert (data_out["avg_delta_dette_par_effectif"] == (0, 50, -0.04)).all()
+    assert (data_out["avg_delta_dette_par_effectif"] == [0, 50, -0.04]).all()
     assert len(data_out.columns) == len(df_test_acoss.columns) + 1
 
 
 def test_paydex_make_yoy():
     data_in = df_test_paydex.copy()
     data_out = paydex_make_yoy(data_in)
-    assert (data_out["paydex_yoy"] == (-81, 0, 9_985)).all()
+    assert (data_out["paydex_yoy"] == [-81, 0, 9_985]).all()
     assert len(data_out.columns) == len(df_test_paydex.columns) + 1
 
 
@@ -49,14 +55,21 @@ def test_paydex_make_group():
     assert len(data_out.columns) == len(df_test_paydex.columns) + 1
 
 
+def test_remove_administrations():
+    data_in = df_test_code_naf.copy()
+    data_out = remove_administrations(data_in)
+    assert (data_out["code_naf"] == ["A", "B", "E"]).all()
+    assert len(data_in) - len(data_out) == 2
+
+
 def test_full_pipeline_sucess():
     data_in = df_test_full.copy()
     data_out = run_pipeline(data_in, pipeline=PIPELINE)
     assert data_out.shape == (3, 11)
     # acoss
-    assert (data_out["avg_delta_dette_par_effectif"] == (0, 50, -0.04)).all()
+    assert (data_out["avg_delta_dette_par_effectif"] == [0, 50, -0.04]).all()
     # paydex yoy
-    assert (data_out["paydex_yoy"] == (-81, 0, 9_985)).all()
+    assert (data_out["paydex_yoy"] == [-81, 0, 9_985]).all()
     # paydex group
     expected = [pd.Interval(0, 15), pd.Interval(15, 30), pd.Interval(90, float("inf"))]
     assert (data_out["paydex_group"] == expected).all()

--- a/tests/unit/preprocessors_test.py
+++ b/tests/unit/preprocessors_test.py
@@ -2,14 +2,11 @@
 import pandas as pd
 import pytest
 from predictsignauxfaibles.preprocessors import (
-    PIPELINE,
     Preprocessor,
     acoss_make_avg_delta_dette_par_effectif,
     paydex_make_groups,
     paydex_make_yoy,
     remove_administrations,
-    run_pipeline,
-    MissingDataError,
 )
 
 from tests.fake_data.dataframes import (
@@ -18,19 +15,6 @@ from tests.fake_data.dataframes import (
     df_test_full,
     df_test_code_naf,
 )
-
-
-def test_final_pipeline():
-    for preprocessor in PIPELINE:
-        assert isinstance(preprocessor, Preprocessor)
-        assert hasattr(preprocessor, "name")
-        assert hasattr(preprocessor, "function")
-        assert hasattr(preprocessor, "input")
-        assert hasattr(preprocessor, "output")
-        assert isinstance(preprocessor.name, str)
-        assert callable(preprocessor.function)
-        assert isinstance(preprocessor.input, list)
-        assert isinstance(preprocessor.output, list) or preprocessor.output is None
 
 
 def test_acoss_make_avg_delta_dette_par_effectif():
@@ -60,23 +44,3 @@ def test_remove_administrations():
     data_out = remove_administrations(data_in)
     assert (data_out["code_naf"] == ["A", "B", "E"]).all()
     assert len(data_in) - len(data_out) == 2
-
-
-def test_full_pipeline_sucess():
-    data_in = df_test_full.copy()
-    data_out = run_pipeline(data_in, pipeline=PIPELINE)
-    assert data_out.shape == (3, 11)
-    # acoss
-    assert (data_out["avg_delta_dette_par_effectif"] == [0, 50, -0.04]).all()
-    # paydex yoy
-    assert (data_out["paydex_yoy"] == [-81, 0, 9_985]).all()
-    # paydex group
-    expected = [pd.Interval(0, 15), pd.Interval(15, 30), pd.Interval(90, float("inf"))]
-    assert (data_out["paydex_group"] == expected).all()
-
-
-def test_full_pipeline_missing_input():
-    data_in = df_test_full.copy()
-    data_in.drop(columns=("code_naf"), inplace=True)
-    with pytest.raises(MissingDataError):
-        run_pipeline(data_in, pipeline=PIPELINE)

--- a/tests/unit/preprocessors_test.py
+++ b/tests/unit/preprocessors_test.py
@@ -1,0 +1,12 @@
+# pylint: disable=missing-function-docstring
+from predictsignauxfaibles.preprocessors import PIPELINE, Preprocessor
+
+
+def test_final_pipeline():
+    for preprocessor in PIPELINE:
+        assert isinstance(preprocessor, Preprocessor)
+        assert hasattr(preprocessor, "function")
+        assert hasattr(preprocessor, "input")
+        assert hasattr(preprocessor, "output")
+        assert isinstance(preprocessor.input, list)
+        assert isinstance(preprocessor.output, list) or preprocessor.output is None

--- a/tests/unit/preprocessors_test.py
+++ b/tests/unit/preprocessors_test.py
@@ -1,11 +1,14 @@
 # pylint: disable=missing-function-docstring
+import pandas as pd
 from predictsignauxfaibles.preprocessors import (
     PIPELINE,
     Preprocessor,
     acoss_make_avg_delta_dette_par_effectif,
+    paydex_make_groups,
+    paydex_make_yoy,
 )
 
-from tests.fake_data.dataframes import df_test_acoss
+from tests.fake_data.dataframes import df_test_acoss, df_test_paydex
 
 
 def test_final_pipeline():
@@ -23,3 +26,18 @@ def test_acoss_make_avg_delta_dette_par_effectif():
     data_out = acoss_make_avg_delta_dette_par_effectif(data_in)
     assert (data_out["avg_delta_dette_par_effectif"] == (0, 50, -0.04)).all()
     assert len(data_out.columns) == len(df_test_acoss.columns) + 1
+
+
+def test_paydex_make_yoy():
+    data_in = df_test_paydex.copy()
+    data_out = paydex_make_yoy(data_in)
+    assert (data_out["paydex_yoy"] == (-81, 0, 9_985)).all()
+    assert len(data_out.columns) == len(df_test_paydex.columns) + 1
+
+
+def test_paydex_make_group():
+    data_in = df_test_paydex.copy()
+    data_out = paydex_make_groups(data_in)
+    expected = [pd.Interval(0, 15), pd.Interval(15, 30), pd.Interval(90, float("inf"))]
+    assert (data_out["paydex_group"] == expected).all()
+    assert len(data_out.columns) == len(df_test_paydex.columns) + 1

--- a/tests/unit/preprocessors_test.py
+++ b/tests/unit/preprocessors_test.py
@@ -1,22 +1,28 @@
 # pylint: disable=missing-function-docstring
 import pandas as pd
+import pytest
 from predictsignauxfaibles.preprocessors import (
     PIPELINE,
     Preprocessor,
     acoss_make_avg_delta_dette_par_effectif,
     paydex_make_groups,
     paydex_make_yoy,
+    run_pipeline,
+    MissingDataError,
 )
 
-from tests.fake_data.dataframes import df_test_acoss, df_test_paydex
+from tests.fake_data.dataframes import df_test_acoss, df_test_paydex, df_test_full
 
 
 def test_final_pipeline():
     for preprocessor in PIPELINE:
         assert isinstance(preprocessor, Preprocessor)
+        assert hasattr(preprocessor, "name")
         assert hasattr(preprocessor, "function")
         assert hasattr(preprocessor, "input")
         assert hasattr(preprocessor, "output")
+        assert isinstance(preprocessor.name, str)
+        assert callable(preprocessor.function)
         assert isinstance(preprocessor.input, list)
         assert isinstance(preprocessor.output, list) or preprocessor.output is None
 
@@ -41,3 +47,23 @@ def test_paydex_make_group():
     expected = [pd.Interval(0, 15), pd.Interval(15, 30), pd.Interval(90, float("inf"))]
     assert (data_out["paydex_group"] == expected).all()
     assert len(data_out.columns) == len(df_test_paydex.columns) + 1
+
+
+def test_full_pipeline_sucess():
+    data_in = df_test_full.copy()
+    data_out = run_pipeline(data_in, pipeline=PIPELINE)
+    assert data_out.shape == (3, 11)
+    # acoss
+    assert (data_out["avg_delta_dette_par_effectif"] == (0, 50, -0.04)).all()
+    # paydex yoy
+    assert (data_out["paydex_yoy"] == (-81, 0, 9_985)).all()
+    # paydex group
+    expected = [pd.Interval(0, 15), pd.Interval(15, 30), pd.Interval(90, float("inf"))]
+    assert (data_out["paydex_group"] == expected).all()
+
+
+def test_full_pipeline_missing_input():
+    data_in = df_test_full.copy()
+    data_in.drop(columns=("code_naf"), inplace=True)
+    with pytest.raises(MissingDataError):
+        run_pipeline(data_in, pipeline=PIPELINE)


### PR DESCRIPTION
- create a `preprocessors` module
- create a Preprocessor "class" (actually, just a `namedtuple`) that stores 3 attributes :
    - a `function` that only takes a dataframe as an input and returns a dataframe
    - `input` which is a list of needed input columns in order to run the function successfully
    - `output` which is either `None` or a list of newly created output columns
 - create a `PIPELINE` object that stores a list of Preprocessors, the idea is to use it something like this :

```python
from predictsignauxfaibles.preprocessors import PIPELINE

my_data = # a DataFrame

# this could be a single preprocessing step or a thousand
for preprocessor in PIPELINE:
    assert set(preprocessor.input).issubset(my_data.columns)
    my_data = preprocessor.function(my_data)
    assert set(preprocessor.output).issubset(my_data.columns)
```


WDYT ?