### PR TITLE
Feat/optional arguments

### DIFF
--- a/models/default/model_conf.py
+++ b/models/default/model_conf.py
@@ -9,7 +9,6 @@ from sklearn.preprocessing import OneHotEncoder, StandardScaler
 from sklearn_pandas import DataFrameMapper
 
 from predictsignauxfaibles.data import SFDataset, OversampledSFDataset
-from predictsignauxfaibles.config import DEFAULT_DATA_VALUES, IGNORE_NA
 from predictsignauxfaibles.pipelines import DEFAULT_PIPELINE
 from predictsignauxfaibles.utils import check_feature
 

--- a/models/default/model_conf.py
+++ b/models/default/model_conf.py
@@ -8,6 +8,8 @@ from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import OneHotEncoder, StandardScaler
 from sklearn_pandas import DataFrameMapper
 
+from predictsignauxfaibles.data import SFDataset, OversampledSFDataset
+from predictsignauxfaibles.config import DEFAULT_DATA_VALUES, IGNORE_NA
 from predictsignauxfaibles.pipelines import DEFAULT_PIPELINE
 from predictsignauxfaibles.utils import check_feature
 
@@ -112,15 +114,34 @@ TRAIN_FROM = "2016-01-01"
 TRAIN_TO = "2018-06-30"
 TRAIN_SAMPLE_SIZE = 1_000_000 if ENV == "prod" else 5_000
 TRAIN_OVERSAMPLING = 0.2
+TRAIN_DATASET = OversampledSFDataset(
+    TRAIN_OVERSAMPLING,
+    date_min=TRAIN_FROM,
+    date_max=TRAIN_TO,
+    fields=VARIABLES,
+    sample_size=TRAIN_SAMPLE_SIZE,
+)
 
 # Test Dataset
 TEST_FROM = "2018-07-01"
 TEST_TO = "2018-10-31"
 TEST_SAMPLE_SIZE = 250_000 if ENV == "prod" else 5_000
+TEST_DATASET = SFDataset(
+    date_min=TEST_FROM,
+    date_max=TEST_TO,
+    fields=VARIABLES,
+    sample_size=TEST_SAMPLE_SIZE,
+)
 
 # Predict Dataset
 PREDICT_ON = "2020-02-01"
 PREDICT_SAMPLE_SIZE = 1_000_000_000 if ENV == "prod" else 5_000
+PREDICT_DATASET = SFDataset(
+    date_min=PREDICT_ON,
+    date_max=PREDICT_ON[:-2] + "28",
+    fields=VARIABLES,
+    sample_size=PREDICT_SAMPLE_SIZE,
+)
 
 # Evaluation parameters
 EVAL_BETA = 2

--- a/models/default/model_conf.py
+++ b/models/default/model_conf.py
@@ -8,6 +8,7 @@ from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import OneHotEncoder, StandardScaler
 from sklearn_pandas import DataFrameMapper
 
+from predictsignauxfaibles.data import SFDataset, OversampledSFDataset
 from predictsignauxfaibles.config import DEFAULT_DATA_VALUES, IGNORE_NA
 from predictsignauxfaibles.pipelines import DEFAULT_PIPELINE
 from predictsignauxfaibles.utils import check_feature
@@ -113,15 +114,34 @@ TRAIN_FROM = "2016-01-01"
 TRAIN_TO = "2018-06-30"
 TRAIN_SAMPLE_SIZE = 1_000_000 if ENV == "prod" else 5_000
 TRAIN_OVERSAMPLING = 0.2
+TRAIN_DATASET = OversampledSFDataset(
+    TRAIN_OVERSAMPLING,
+    date_min=TRAIN_FROM,
+    date_max=TRAIN_TO,
+    fields=VARIABLES,
+    sample_size=TRAIN_SAMPLE_SIZE,
+)
 
 # Test Dataset
 TEST_FROM = "2018-07-01"
 TEST_TO = "2018-10-31"
 TEST_SAMPLE_SIZE = 1_000_000 if ENV == "prod" else 5_000
+TEST_DATASET = SFDataset(
+    date_min=TEST_FROM,
+    date_max=TEST_TO,
+    fields=VARIABLES,
+    sample_size=TEST_SAMPLE_SIZE,
+)
 
 # Predict Dataset
 PREDICT_ON = "2020-02-01"
 PREDICT_SAMPLE_SIZE = 1_000_000_000 if ENV == "prod" else 5_000
+PREDICT_DATASET = SFDataset(
+    date_min=PREDICT_ON,
+    date_max=PREDICT_ON[:-2] + "28",
+    fields=VARIABLES,
+    sample_size=PREDICT_SAMPLE_SIZE,
+)
 
 # Evaluation parameters
 EVAL_BETA = 2

--- a/predictsignauxfaibles/__main__.py
+++ b/predictsignauxfaibles/__main__.py
@@ -62,6 +62,7 @@ def load_datasets_from_conf(args_ns, conf):
     }
 
     stats = {}
+
     args_dict = vars(args_ns)
     for (arg, dest) in args_to_attrs.items():
         set_if_not_none(datasets[dest[0]], dest[1], args_dict[arg])
@@ -243,7 +244,7 @@ predict_args.add_argument(
     """,
 )
 
-run_model_args = parser.parse_args()
+model_args = parser.parse_args()
 
 if __name__ == "__main__":
-    run(run_model_args)
+    run(model_args)

--- a/predictsignauxfaibles/__main__.py
+++ b/predictsignauxfaibles/__main__.py
@@ -5,11 +5,12 @@ import json
 from pathlib import Path
 import sys
 import logging
+import pdb
 
 from sklearn.metrics import fbeta_score, balanced_accuracy_score
-from predictsignauxfaibles.config import OUTPUT_FOLDER, IGNORE_NA
+from predictsignauxfaibles.config import OUTPUT_FOLDER
 from predictsignauxfaibles.pipelines import run_pipeline
-from predictsignauxfaibles.data import OversampledSFDataset, SFDataset
+from predictsignauxfaibles.utils import set_if_not_none
 
 sys.path.append("../")
 
@@ -18,11 +19,23 @@ logging.basicConfig(format="%(asctime)s - %(levelname)s - %(message)s", level="I
 # Mute logs from sklean_pandas
 logging.getLogger("sklearn_pandas").setLevel(logging.WARNING)
 
+args_to_attrs = {
+    "train_spl_size": ("train", "sample_size"),
+    "test_spl_size": ("test", "sample_size"),
+    "predict_spl_size": ("predict", "sample_size"),
+    "train_proportion_positive_class": ("train", "proportion_positive_class"),
+    "train_from": ("train", "date_min"),
+    "train_to": ("train", "date_max"),
+    "test_from": ("test", "date_min"),
+    "test_to": ("test", "date_max"),
+    "predict_on": ("predict", "date_min"),
+}
 
-def load_conf(args):
+
+def load_conf(args):  # pylint: disable=redefined-outer-name
     """
     Loads a model configuration from a argparse.Namespace
-    containing a model name and a configuration filename
+    containing a model name
     Args:
         conf_args: a argparse.Namespace object containing attributes
             model_name
@@ -39,8 +52,31 @@ def load_conf(args):
     return model_conf
 
 
+def load_datasets_from_conf(args_ns, conf):
+    """
+    Configures train, test and predict dataset from user-provided options when pertaining.
+    """
+    datasets = {
+        "train": conf.TRAIN_DATASET,
+        "test": conf.TEST_DATASET,
+        "predict": conf.PREDICT_DATASET,
+    }
+
+    stats = {}
+
+    args_dict = vars(args_ns)
+    for (arg, dest) in args_to_attrs.items():
+        set_if_not_none(datasets[dest[0]], dest[1], args_dict[arg])
+        stats[arg] = getattr(datasets[dest[0]], dest[1])
+
+    if args_ns.predict_on is not None:
+        datasets["predict"].date_max = args_ns.predict_on[:-2] + "28"
+
+    return (datasets["train"], datasets["test"], datasets["predict"]), stats
+
+
 def evaluate(
-    model, dataset
+    model, dataset, beta
 ):  # To be turned into a SFModel method when refactoring models
     """
     Returns evaluation metrics of model evaluated on df
@@ -51,43 +87,38 @@ def evaluate(
     balanced_accuracy = balanced_accuracy_score(
         dataset.data["outcome"], model.predict(dataset.data)
     )
-    fbeta = fbeta_score(
-        dataset.data["outcome"], model.predict(dataset.data), beta=conf.EVAL_BETA
-    )
+    fbeta = fbeta_score(dataset.data["outcome"], model.predict(dataset.data), beta=beta)
     return {"balanced_accuracy": balanced_accuracy, "fbeta": fbeta}
 
 
-def run():  # pylint: disable=too-many-statements,too-many-locals
+def run(
+    args,
+):  # pylint: disable=too-many-statements,too-many-locals
     """
     Run model
     """
-    logging.info(
-        f"Running Model {conf.MODEL_ID} (commit {conf.MODEL_GIT_SHA}) ENV={conf.ENV}"
-    )
-    model_stats = {}
+    conf = load_conf(args)
+    logging.info(f"Running Model {conf.MODEL_ID} (commit {conf.MODEL_GIT_SHA})")
     model_id = datetime.now().strftime("%Y%m%d-%H%M%S")
+
+    datasets, model_stats = load_datasets_from_conf(args, conf)
+    (train_dataset, test_dataset, predict_dataset) = datasets
     model_stats["run_on"] = model_id
 
+    pdb.set_trace()
     step = "[TRAIN]"
     model_stats["train"] = {}
-    train_dataset = OversampledSFDataset(
-        conf.TRAIN_OVERSAMPLING,
-        date_min=conf.TRAIN_FROM,
-        date_max=conf.TRAIN_TO,
-        fields=conf.VARIABLES,
-        sample_size=conf.TRAIN_SAMPLE_SIZE,
-    )
-    logging.info(f"{step} - Fetching train set")
+    logging.info(f"{step} - Fetching train set ({train_dataset.sample_size} samples)")
     train_dataset.fetch_data()
 
     logging.info(f"{step} - Data preprocessing")
-    train_dataset.replace_missing_data().remove_na(ignore=IGNORE_NA)
+    train_dataset.replace_missing_data().remove_na(ignore=["time_til_outcome"])
     train_dataset.data = run_pipeline(train_dataset.data, conf.TRANSFO_PIPELINE)
 
     logging.info(f"{step} - Training on {len(train_dataset)} observations.")
     fit = conf.MODEL_PIPELINE.fit(train_dataset.data, train_dataset.data["outcome"])
 
-    eval_metrics = evaluate(fit, train_dataset)
+    eval_metrics = evaluate(fit, train_dataset, conf.EVAL_BETA)
     balanced_accuracy_train = eval_metrics.get("balanced_accuracy")
     fbeta_train = eval_metrics.get("fbeta")
     logging.info(f"{step} - Balanced_accuracy: {balanced_accuracy_train}")
@@ -97,13 +128,7 @@ def run():  # pylint: disable=too-many-statements,too-many-locals
 
     step = "[TEST]"
     model_stats["test"] = {}
-    test_dataset = SFDataset(
-        date_min=conf.TEST_FROM,
-        date_max=conf.TEST_TO,
-        fields=conf.VARIABLES,
-        sample_size=conf.TEST_SAMPLE_SIZE,
-    )
-    logging.info(f"{step} - Fetching test set")
+    logging.info(f"{step} - Fetching test set ({test_dataset.sample_size} samples)")
     test_dataset.fetch_data()
 
     train_siren_set = train_dataset.data["siren"].unique().tolist()
@@ -111,12 +136,12 @@ def run():  # pylint: disable=too-many-statements,too-many-locals
 
     logging.info(f"{step} - Data preprocessing")
     test_dataset.replace_missing_data().remove_na(
-        ignore=IGNORE_NA
+        ignore=["time_til_outcome"]
     ).remove_strong_signals()
     test_dataset.data = run_pipeline(test_dataset.data, conf.TRANSFO_PIPELINE)
     logging.info(f"{step} - Testing on {len(test_dataset)} observations.")
 
-    eval_metrics = evaluate(fit, test_dataset)
+    eval_metrics = evaluate(fit, test_dataset, conf.EVAL_BETA)
     balanced_accuracy_test = eval_metrics.get("balanced_accuracy")
     fbeta_test = eval_metrics.get("fbeta")
     logging.info(f"{step} - Balanced_accuracy: {balanced_accuracy_test}")
@@ -127,17 +152,11 @@ def run():  # pylint: disable=too-many-statements,too-many-locals
     step = "[PREDICT]"
     model_stats["predict"] = {}
 
-    predict_dataset = SFDataset(
-        date_min=conf.PREDICT_ON,
-        date_max=conf.PREDICT_ON[:-2] + "28",
-        fields=conf.VARIABLES,
-        sample_size=conf.PREDICT_SAMPLE_SIZE,
-    )
     logging.info(f"{step} - Fetching predict set")
     predict_dataset.fetch_data()
     logging.info(f"{step} - Data preprocessing")
     predict_dataset.replace_missing_data()
-    predict_dataset.remove_na(ignore=IGNORE_NA + ["outcome"])
+    predict_dataset.remove_na(ignore=["time_til_outcome", "outcome"])
     predict_dataset.data = run_pipeline(predict_dataset.data, conf.TRANSFO_PIPELINE)
     logging.info(f"{step} - Predicting on {len(predict_dataset)} observations.")
     predictions = fit.predict_proba(predict_dataset.data)
@@ -163,13 +182,71 @@ parser.add_argument(
     "--model_name",
     type=str,
     default="default",
-    help="The model to use for prediction. If not provided, models/default will be used",
+    help="The model to use for prediction. If not provided, models default will be used",
 )
 
-conf_args = parser.parse_args()
+train_args = parser.add_argument_group("Train dataset")
+train_args.add_argument(
+    "--train_sample",
+    type=int,
+    dest="train_spl_size",
+    help="Train the model on data from this date",
+)
+train_args.add_argument(
+    "--oversampling",
+    type=float,
+    dest="train_proportion_positive_class",
+    help="""
+    Enforces the ratio of positive observations
+    (entreprises en defaillance) to be the specified ratio
+    """,
+)
+train_args.add_argument(
+    "--train_from",
+    type=str,
+    help="Train the model on data from this date",
+)
+train_args.add_argument(
+    "--train_to",
+    type=str,
+    help="Train the model on data up to this date",
+)
 
-conf = load_conf(conf_args)
+test_args = parser.add_argument_group("Test dataset")
+test_args.add_argument(
+    "--test_sample",
+    type=int,
+    dest="test_spl_size",
+    help="The sample size to test the model on",
+)
+test_args.add_argument(
+    "--test_from",
+    type=str,
+    help="Test the model on data from this date",
+)
+test_args.add_argument(
+    "--test_to",
+    type=str,
+    help="Test the model on data up to this date",
+)
 
+predict_args = parser.add_argument_group("Predict dataset")
+predict_args.add_argument(
+    "--predict_sample",
+    type=int,
+    dest="predict_spl_size",
+    help="The sample size to predict on",
+)
+predict_args.add_argument(
+    "--predict_on",
+    type=str,
+    help="""
+    Predict on all companies for the month specified.
+    To predict on April 2021, provide any date such as '01-04-2021'
+    """,
+)
+
+run_model_args = parser.parse_args()
 
 if __name__ == "__main__":
-    run()
+    run(run_model_args)

--- a/predictsignauxfaibles/__main__.py
+++ b/predictsignauxfaibles/__main__.py
@@ -5,7 +5,6 @@ import json
 from pathlib import Path
 import sys
 import logging
-import pdb
 
 from sklearn.metrics import fbeta_score, balanced_accuracy_score
 from predictsignauxfaibles.config import OUTPUT_FOLDER
@@ -105,7 +104,6 @@ def run(
     (train_dataset, test_dataset, predict_dataset) = datasets
     model_stats["run_on"] = model_id
 
-    pdb.set_trace()
     step = "[TRAIN]"
     model_stats["train"] = {}
     logging.info(f"{step} - Fetching train set ({train_dataset.sample_size} samples)")

--- a/predictsignauxfaibles/__main__.py
+++ b/predictsignauxfaibles/__main__.py
@@ -5,7 +5,6 @@ import json
 from pathlib import Path
 import sys
 import logging
-import pdb
 
 from sklearn.metrics import fbeta_score, balanced_accuracy_score
 from predictsignauxfaibles.config import OUTPUT_FOLDER
@@ -63,7 +62,6 @@ def load_datasets_from_conf(args_ns, conf):
     }
 
     stats = {}
-
     args_dict = vars(args_ns)
     for (arg, dest) in args_to_attrs.items():
         set_if_not_none(datasets[dest[0]], dest[1], args_dict[arg])
@@ -105,7 +103,6 @@ def run(
     (train_dataset, test_dataset, predict_dataset) = datasets
     model_stats["run_on"] = model_id
 
-    pdb.set_trace()
     step = "[TRAIN]"
     model_stats["train"] = {}
     logging.info(f"{step} - Fetching train set ({train_dataset.sample_size} samples)")

--- a/predictsignauxfaibles/__main__.py
+++ b/predictsignauxfaibles/__main__.py
@@ -201,77 +201,83 @@ def run(
         stats_file.write(json.dumps(model_stats))
 
 
-parser = argparse.ArgumentParser("main.py", description="Run model prediction")
+def make_parser():
+    """
+    Builds a parser object with all arguments to run a custom version of prediction
+    """
+    parser = argparse.ArgumentParser("main.py", description="Run model prediction")
 
-parser.add_argument(
-    "--model_name",
-    type=str,
-    default="default",
-    help="The model to use for prediction. If not provided, models 'default' will be used",
-)
+    parser.add_argument(
+        "--model_name",
+        type=str,
+        default="default",
+        help="The model to use for prediction. If not provided, models 'default' will be used",
+    )
 
-train_args = parser.add_argument_group("Train dataset")
-train_args.add_argument(
-    "--train_sample",
-    type=int,
-    dest="train_spl_size",
-    help="Train the model on data from this date",
-)
-train_args.add_argument(
-    "--oversampling",
-    type=float,
-    dest="train_proportion_positive_class",
-    help="""
-    Enforces the ratio of positive observations
-    (entreprises en defaillance) to be the specified ratio
-    """,
-)
-train_args.add_argument(
-    "--train_from",
-    type=str,
-    help="Train the model on data from this date",
-)
-train_args.add_argument(
-    "--train_to",
-    type=str,
-    help="Train the model on data up to this date",
-)
+    train_args = parser.add_argument_group("Train dataset")
+    train_args.add_argument(
+        "--train_sample",
+        type=int,
+        dest="train_spl_size",
+        help="Train the model on data from this date",
+    )
+    train_args.add_argument(
+        "--oversampling",
+        type=float,
+        dest="train_proportion_positive_class",
+        help="""
+        Enforces the ratio of positive observations
+        (entreprises en defaillance) to be the specified ratio
+        """,
+    )
+    train_args.add_argument(
+        "--train_from",
+        type=str,
+        help="Train the model on data from this date",
+    )
+    train_args.add_argument(
+        "--train_to",
+        type=str,
+        help="Train the model on data up to this date",
+    )
 
-test_args = parser.add_argument_group("Test dataset")
-test_args.add_argument(
-    "--test_sample",
-    type=int,
-    dest="test_spl_size",
-    help="The sample size to test the model on",
-)
-test_args.add_argument(
-    "--test_from",
-    type=str,
-    help="Test the model on data from this date",
-)
-test_args.add_argument(
-    "--test_to",
-    type=str,
-    help="Test the model on data up to this date",
-)
+    test_args = parser.add_argument_group("Test dataset")
+    test_args.add_argument(
+        "--test_sample",
+        type=int,
+        dest="test_spl_size",
+        help="The sample size to test the model on",
+    )
+    test_args.add_argument(
+        "--test_from",
+        type=str,
+        help="Test the model on data from this date",
+    )
+    test_args.add_argument(
+        "--test_to",
+        type=str,
+        help="Test the model on data up to this date",
+    )
 
-predict_args = parser.add_argument_group("Predict dataset")
-predict_args.add_argument(
-    "--predict_sample",
-    type=int,
-    dest="predict_spl_size",
-    help="The sample size to predict on",
-)
-predict_args.add_argument(
-    "--predict_on",
-    type=str,
-    help="""
-    Predict on all companies for the month specified.
-    To predict on April 2021, provide any date such as '2021-04-01'
-    """,
-)
+    predict_args = parser.add_argument_group("Predict dataset")
+    predict_args.add_argument(
+        "--predict_sample",
+        type=int,
+        dest="predict_spl_size",
+        help="The sample size to predict on",
+    )
+    predict_args.add_argument(
+        "--predict_on",
+        type=str,
+        help="""
+        Predict on all companies for the month specified.
+        To predict on April 2021, provide any date such as '2021-04-01'
+        """,
+    )
 
-model_args = parser.parse_args()
+    return parser
+
 
 if __name__ == "__main__":
+    model_args = make_parser().parse_args()
     run(model_args)

--- a/predictsignauxfaibles/__main__.py
+++ b/predictsignauxfaibles/__main__.py
@@ -9,7 +9,7 @@ import logging
 from sklearn.metrics import fbeta_score, balanced_accuracy_score
 from predictsignauxfaibles.config import OUTPUT_FOLDER
 from predictsignauxfaibles.pipelines import run_pipeline
-from predictsignauxfaibles.data import OversampledSFDataset, SFDataset
+from predictsignauxfaibles.utils import fill_if_not_none
 
 sys.path.append("../")
 
@@ -18,11 +18,22 @@ logging.basicConfig(format="%(asctime)s - %(levelname)s - %(message)s", level="I
 # Mute logs from sklean_pandas
 logging.getLogger("sklearn_pandas").setLevel(logging.WARNING)
 
+args_to_attrs = {
+    "train_spl_size": ("train", "sample_size"),
+    "test_spl_size": ("test", "sample_size"),
+    "predict_spl_size": ("predict", "sample_size"),
+    "train_proportion_positive_class": ("train", "proportion_positive_class"),
+    "train_from": ("train", "date_min"),
+    "train_to": ("train", "date_max"),
+    "test_from": ("test", "date_min"),
+    "test_to": ("test", "date_max"),
+}
 
-def load_conf(args):
+
+def load_conf(args):  # pylint: disable=redefined-outer-name
     """
     Loads a model configuration from a argparse.Namespace
-    containing a model name and a configuration filename
+    containing a model name
     Args:
         conf_args: a argparse.Namespace object containing attributes
             model_name
@@ -39,8 +50,29 @@ def load_conf(args):
     return model_conf
 
 
+def load_datasets_from_conf(args_ns, conf):
+    """
+    Configures train, test and predict dataset from user-provided options when pertaining.
+    """
+    datasets = {
+        "train": conf.TRAIN_DATASET,
+        "test": conf.TEST_DATASET,
+        "predict": conf.PREDICT_DATASET,
+    }
+
+    args_dict = vars(args_ns)
+    for (arg, dest) in args_to_attrs.items():
+        fill_if_not_none(datasets[dest[0]], dest[1], args_dict[arg])
+
+    if args.predict_on is not None:
+        datasets["predict"].date_min = args.predict_on
+        datasets["predict"].date_max = args.predict_on[:-2] + "28"
+
+    return (datasets["train"], datasets["test"], datasets["predict"])
+
+
 def evaluate(
-    model, dataset
+    model, dataset, beta
 ):  # To be turned into a SFModel method when refactoring models
     """
     Returns evaluation metrics of model evaluated on df
@@ -51,30 +83,26 @@ def evaluate(
     balanced_accuracy = balanced_accuracy_score(
         dataset.data["outcome"], model.predict(dataset.data)
     )
-    fbeta = fbeta_score(
-        dataset.data["outcome"], model.predict(dataset.data), beta=conf.EVAL_BETA
-    )
+    fbeta = fbeta_score(dataset.data["outcome"], model.predict(dataset.data), beta=beta)
     return {"balanced_accuracy": balanced_accuracy, "fbeta": fbeta}
 
 
-def run(): # pylint: disable=too-many-statements,too-many-locals
+def run(
+    args,
+):  # pylint: disable=redefined-outer-name,too-many-statements,too-many-locals
     """
     Run model
     """
+    conf = load_conf(args)
     logging.info(f"Running Model {conf.MODEL_ID} (commit {conf.MODEL_GIT_SHA})")
-    model_stats = {}
+    model_stats = vars(args)
     model_id = datetime.now().strftime("%Y%m%d-%H%M%S")
     model_stats["run_on"] = model_id
 
+    (train_dataset, test_dataset, predict_dataset) = load_datasets_from_conf(args, conf)
+
     step = "[TRAIN]"
     model_stats["train"] = {}
-    train_dataset = OversampledSFDataset(
-        conf.TRAIN_OVERSAMPLING,
-        date_min=conf.TRAIN_FROM,
-        date_max=conf.TRAIN_TO,
-        fields=conf.VARIABLES,
-        sample_size=conf.TRAIN_SAMPLE_SIZE,
-    )
     logging.info(f"{step} - Fetching train set")
     train_dataset.fetch_data()
 
@@ -85,7 +113,7 @@ def run(): # pylint: disable=too-many-statements,too-many-locals
     logging.info(f"{step} - Training on {len(train_dataset)} observations.")
     fit = conf.MODEL_PIPELINE.fit(train_dataset.data, train_dataset.data["outcome"])
 
-    eval_metrics = evaluate(fit, train_dataset)
+    eval_metrics = evaluate(fit, train_dataset, conf.EVAL_BETA)
     balanced_accuracy_train = eval_metrics.get("balanced_accuracy")
     fbeta_train = eval_metrics.get("fbeta")
     logging.info(f"{step} - Balanced_accuracy: {balanced_accuracy_train}")
@@ -95,12 +123,6 @@ def run(): # pylint: disable=too-many-statements,too-many-locals
 
     step = "[TEST]"
     model_stats["test"] = {}
-    test_dataset = SFDataset(
-        date_min=conf.TEST_FROM,
-        date_max=conf.TEST_TO,
-        fields=conf.VARIABLES,
-        sample_size=conf.TEST_SAMPLE_SIZE,
-    )
     logging.info(f"{step} - Fetching test set")
     test_dataset.fetch_data()
 
@@ -114,7 +136,7 @@ def run(): # pylint: disable=too-many-statements,too-many-locals
     test_dataset.data = run_pipeline(test_dataset.data, conf.TRANSFO_PIPELINE)
     logging.info(f"{step} - Testing on {len(test_dataset)} observations.")
 
-    eval_metrics = evaluate(fit, test_dataset)
+    eval_metrics = evaluate(fit, test_dataset, conf.EVAL_BETA)
     balanced_accuracy_test = eval_metrics.get("balanced_accuracy")
     fbeta_test = eval_metrics.get("fbeta")
     logging.info(f"{step} - Balanced_accuracy: {balanced_accuracy_test}")
@@ -125,12 +147,6 @@ def run(): # pylint: disable=too-many-statements,too-many-locals
     step = "[PREDICT]"
     model_stats["predict"] = {}
 
-    predict_dataset = SFDataset(
-        date_min=conf.PREDICT_ON,
-        date_max=conf.PREDICT_ON[:-2] + "28",
-        fields=conf.VARIABLES,
-        sample_size=conf.PREDICT_SAMPLE_SIZE,
-    )
     logging.info(f"{step} - Fetching predict set")
     predict_dataset.fetch_data()
     logging.info(f"{step} - Data preprocessing")
@@ -161,13 +177,71 @@ parser.add_argument(
     "--model_name",
     type=str,
     default="default",
-    help="The model to use for prediction. If not provided, models/default will be used",
+    help="The model to use for prediction. If not provided, models default will be used",
 )
 
-conf_args = parser.parse_args()
+train_args = parser.add_argument_group("Train dataset")
+train_args.add_argument(
+    "--train_sample",
+    type=int,
+    dest="train_spl_size",
+    help="Train the model on data from this date",
+)
+train_args.add_argument(
+    "--oversampling",
+    type=float,
+    dest="train_proportion_positive_class",
+    help="""
+    Enforces the ratio of positive observations
+    (entreprises en defaillance) to be the specified ratio
+    """,
+)
+train_args.add_argument(
+    "--train_from",
+    type=str,
+    help="Train the model on data from this date",
+)
+train_args.add_argument(
+    "--train_to",
+    type=str,
+    help="Train the model on data up to this date",
+)
 
-conf = load_conf(conf_args)
+test_args = parser.add_argument_group("Test dataset")
+test_args.add_argument(
+    "--test_sample",
+    type=int,
+    dest="test_spl_size",
+    help="The sample size to test the model on",
+)
+test_args.add_argument(
+    "--test_from",
+    type=str,
+    help="Test the model on data from this date",
+)
+test_args.add_argument(
+    "--test_to",
+    type=str,
+    help="Test the model on data up to this date",
+)
 
+predict_args = parser.add_argument_group("Predict dataset")
+predict_args.add_argument(
+    "--predict_sample",
+    type=int,
+    dest="predict_spl_size",
+    help="The sample size to predict on",
+)
+predict_args.add_argument(
+    "--predict_on",
+    type=str,
+    help="""
+    Predict on all companies for the month specified.
+    To predict on April 2021, provide any date such as '01-04-2021'
+    """,
+)
+
+args = parser.parse_args()
 
 if __name__ == "__main__":
-    run()
+    run(args)

--- a/predictsignauxfaibles/__main__.py
+++ b/predictsignauxfaibles/__main__.py
@@ -28,7 +28,7 @@ args_to_attrs = {
     "train_to": ("train", "date_max"),
     "test_from": ("test", "date_min"),
     "test_to": ("test", "date_max"),
-    "predict_on": ("predict", "date_min")
+    "predict_on": ("predict", "date_min"),
 }
 
 
@@ -61,9 +61,9 @@ def load_datasets_from_conf(args_ns, conf):
         "test": conf.TEST_DATASET,
         "predict": conf.PREDICT_DATASET,
     }
-    
+
     stats = {}
-    
+
     args_dict = vars(args_ns)
     for (arg, dest) in args_to_attrs.items():
         set_if_not_none(datasets[dest[0]], dest[1], args_dict[arg])
@@ -104,7 +104,7 @@ def run(
     datasets, model_stats = load_datasets_from_conf(args, conf)
     (train_dataset, test_dataset, predict_dataset) = datasets
     model_stats["run_on"] = model_id
-    
+
     pdb.set_trace()
     step = "[TRAIN]"
     model_stats["train"] = {}

--- a/predictsignauxfaibles/__main__.py
+++ b/predictsignauxfaibles/__main__.py
@@ -8,7 +8,7 @@ import logging
 from types import ModuleType
 
 from sklearn.metrics import fbeta_score, balanced_accuracy_score
-from predictsignauxfaibles.config import OUTPUT_FOLDER
+from predictsignauxfaibles.config import OUTPUT_FOLDER, IGNORE_NA
 from predictsignauxfaibles.pipelines import run_pipeline
 from predictsignauxfaibles.utils import set_if_not_none
 
@@ -118,7 +118,7 @@ def run(
     train_dataset.fetch_data()
 
     logging.info(f"{step} - Data preprocessing")
-    train_dataset.replace_missing_data().remove_na(ignore=["time_til_outcome"])
+    train_dataset.replace_missing_data().remove_na(ignore=IGNORE_NA)
     train_dataset.data = run_pipeline(train_dataset.data, conf.TRANSFO_PIPELINE)
 
     logging.info(f"{step} - Training on {len(train_dataset)} observations.")
@@ -142,7 +142,7 @@ def run(
 
     logging.info(f"{step} - Data preprocessing")
     test_dataset.replace_missing_data().remove_na(
-        ignore=["time_til_outcome"]
+        ignore=IGNORE_NA
     ).remove_strong_signals()
     test_dataset.data = run_pipeline(test_dataset.data, conf.TRANSFO_PIPELINE)
     logging.info(f"{step} - Testing on {len(test_dataset)} observations.")
@@ -162,7 +162,7 @@ def run(
     predict_dataset.fetch_data()
     logging.info(f"{step} - Data preprocessing")
     predict_dataset.replace_missing_data()
-    predict_dataset.remove_na(ignore=["time_til_outcome", "outcome"])
+    predict_dataset.remove_na(ignore=IGNORE_NA)
     predict_dataset.data = run_pipeline(predict_dataset.data, conf.TRANSFO_PIPELINE)
     logging.info(f"{step} - Predicting on {len(predict_dataset)} observations.")
     predictions = fit.predict_proba(predict_dataset.data)
@@ -188,7 +188,7 @@ parser.add_argument(
     "--model_name",
     type=str,
     default="default",
-    help="The model to use for prediction. If not provided, models default will be used",
+    help="The model to use for prediction. If not provided, models 'default' will be used",
 )
 
 train_args = parser.add_argument_group("Train dataset")
@@ -248,7 +248,7 @@ predict_args.add_argument(
     type=str,
     help="""
     Predict on all companies for the month specified.
-    To predict on April 2021, provide any date such as '01-04-2021'
+    To predict on April 2021, provide any date such as '2021-04-01'
     """,
 )
 

--- a/predictsignauxfaibles/utils.py
+++ b/predictsignauxfaibles/utils.py
@@ -163,7 +163,7 @@ def check_feature(feature_name: str, variables: list, pipeline: List[NamedTuple]
     return is_ok
 
 
-def fill_if_not_none(obj, attr, val):
+def set_if_not_none(obj, attr, val):
     """
     Sets the attribute of an object with some value if that value is not null
     Args:

--- a/predictsignauxfaibles/utils.py
+++ b/predictsignauxfaibles/utils.py
@@ -161,3 +161,15 @@ def check_feature(feature_name: str, variables: list, pipeline: List[NamedTuple]
         if step.output is not None and feature_name in step.output:
             is_ok = True
     return is_ok
+
+
+def set_if_not_none(obj, attr, val):
+    """
+    Sets the attribute of an object with some value if that value is not null
+    Args:
+        obj: any object
+        attr: the attribute to be set
+        val: the value to set. If None, attr will remain unchanged
+    """
+    if val is not None:
+        setattr(obj, attr, val)

--- a/predictsignauxfaibles/utils.py
+++ b/predictsignauxfaibles/utils.py
@@ -161,3 +161,15 @@ def check_feature(feature_name: str, variables: list, pipeline: List[NamedTuple]
         if step.output is not None and feature_name in step.output:
             is_ok = True
     return is_ok
+
+
+def fill_if_not_none(obj, attr, val):
+    """
+    Sets the attribute of an object with some value if that value is not null
+    Args:
+        obj: any object
+        attr: the attribute to be set
+        val: the value to set. If None, attr will remain unchanged
+    """
+    if val is not None:
+        setattr(obj, attr, val)

--- a/tests/integration/test_modelrun_components.py
+++ b/tests/integration/test_modelrun_components.py
@@ -1,16 +1,5 @@
-import unittest
 import predictsignauxfaibles.__main__ as main
 from predictsignauxfaibles.data import SFDataset, OversampledSFDataset
-
-
-class ParserTest(unittest.TestCase): # pylint: disable=too-few-public-methods
-    """
-    Class to test functionnalities of the parser we build
-    to process optionnal arguments
-    """
-
-    def setUp(self):
-        self.parser = main.make_parser()
 
 
 def test_args_to_attrs_consistency():
@@ -22,9 +11,7 @@ def test_args_to_attrs_consistency():
     my_dataset = SFDataset()
     my_os_dataset = OversampledSFDataset(proportion_positive_class=0.3)
 
-    assert (main.ARGS_TO_ATTRS is not None) and isinstance(
-        main.ARGS_TO_ATTRS, dict
-    )
+    assert (main.ARGS_TO_ATTRS is not None) and isinstance(main.ARGS_TO_ATTRS, dict)
     for arg, dataset_attr in main.ARGS_TO_ATTRS.items():
         assert arg in args_directory.keys()
         if dataset_attr[0] == "train":

--- a/tests/integration/test_modelrun_components.py
+++ b/tests/integration/test_modelrun_components.py
@@ -1,0 +1,33 @@
+import unittest
+import predictsignauxfaibles.__main__ as main
+from predictsignauxfaibles.data import SFDataset, OversampledSFDataset
+
+
+class ParserTest(unittest.TestCase): # pylint: disable=too-few-public-methods
+    """
+    Class to test functionnalities of the parser we build
+    to process optionnal arguments
+    """
+
+    def setUp(self):
+        self.parser = main.make_parser()
+
+
+def test_args_to_attrs_consistency():
+    """
+    Tests whether optionnal arguments that can be passed to run our package
+    are correctly processed to configure our train/test/predict datasets
+    """
+    args_directory = vars(main.make_parser().parse_args())
+    my_dataset = SFDataset()
+    my_os_dataset = OversampledSFDataset(proportion_positive_class=0.3)
+
+    assert (main.ARGS_TO_ATTRS is not None) and isinstance(
+        main.ARGS_TO_ATTRS, dict
+    )
+    for arg, dataset_attr in main.ARGS_TO_ATTRS.items():
+        assert arg in args_directory.keys()
+        if dataset_attr[0] == "train":
+            assert hasattr(my_os_dataset, dataset_attr[1])
+        else:
+            assert hasattr(my_dataset, dataset_attr[1])

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-function-docstring
 
-from predictsignauxfaibles.utils import MongoDBQuery
+from predictsignauxfaibles.utils import MongoDBQuery, set_if_not_none
 
 
 def test_empty_pipeline():
@@ -85,3 +85,28 @@ def test_reset_pipeline():
         query.add_limit(limit=i)
         assert len(query.to_pipeline()) == 1
         query.reset()
+
+
+def test_set_if_not_none():
+    class TestObject:  # pylint: disable=too-few-public-methods
+        """
+        Test class
+        ...
+        Attributes
+        ----------
+        my_attr_1: str
+            should be modified  by test
+        my_attr_2: str
+            should not be modified by test
+        """
+
+        def __init__(self):
+            self.my_attr_1 = "foo"
+            self.my_attr_2 = 1
+
+    my_obj = TestObject()
+    set_if_not_none(my_obj, "my_attr_1", "bar")
+    set_if_not_none(my_obj, "my_attr_2", None)
+
+    assert my_obj.my_attr_1 == "bar"
+    assert my_obj.my_attr_2 == 1


### PR DESCRIPTION
This branch adds optional arguments to `python3 -m predictsignauxfaibles` using `argparse`, and stores final values used for training, testing and predicting into dictionary `model_stats`. 
Solves #46: as he `ArgumentParser` is called once with all optional arguments considered, the help message becomes exhaustive. You can now try `python3 -m predictsignauxfaibles --help` and get a full list of optional arguments, including the size of the training/test/predict sets, the starting and ending date determining train and test sets, and the month to predict failures on.