### PR TITLE
fix: fill missing fields after fetching data

### DIFF
--- a/predictsignauxfaibles/data.py
+++ b/predictsignauxfaibles/data.py
@@ -1,6 +1,7 @@
 import logging
 
 import pandas as pd
+from numpy import nan as NAN
 from numpy.random import rand, randint
 from pymongo import MongoClient, monitoring
 from pymongo.cursor import Cursor
@@ -139,6 +140,15 @@ class SFDataset:
             raise exception
         finally:
             cursor.close()
+
+        # create and fill missing fields with NAs
+        if not set(self.fields).issubset(set(self.data.columns)):
+            missing = set(self.fields) - set(self.data.columns)
+            logging.info(
+                f"Creating missing columns {missing} and filling them with NAs."
+            )
+            for feat in missing:
+                self.data[feat] = NAN
 
         return self
 


### PR DESCRIPTION
```
> $ ipython
Python 3.6.8 (default, Feb 17 2021, 16:19:03) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.16.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: %config Completer.use_jedi = False

In [2]: from predictsignauxfaibles.data import SFDataset

In [3]: dataset = SFDataset(fields = ["outcome", "column_that_doesnt_exist", "ca"], sample_size=10)

In [4]: dataset.fetch_data()
Out[4]: 

Signaux Faibles Dataset
----------------------------------------------------
   outcome       ca  column_that_doesnt_exist
0    False  81513.0                       NaN
1     True   4892.0                       NaN
2    False      NaN                       NaN
3    False      NaN                       NaN
4    False      NaN                       NaN
[...]
----------------------------------------------------
Number of observations = 10
```


closes #43