### PR TITLE
feat: add preparation step to redressement urssaf

### DIFF
--- a/predictsignauxfaibles/pipelines.py
+++ b/predictsignauxfaibles/pipelines.py
@@ -14,6 +14,7 @@ from predictsignauxfaibles.preprocessors import (
 from predictsignauxfaibles.redressements import (
     Redressement,
     redressement_urssaf_covid,
+    prepare_redressement_urssaf_covid,
 )
 
 
@@ -117,6 +118,18 @@ SMALL_PIPELINE = [
 # Redressements
 
 REDRESSEMENTS_PIPELINE = [
+    Redressement(
+        "Prepare redressement URSSAF",
+        prepare_redressement_urssaf_covid,
+        input=["siret", "siren"],
+        output=[
+            "montant_part_ouvriere_latest",
+            "montant_part_patronale_latest",
+            "montant_part_ouvriere_july2020",
+            "montant_part_patronale_july2020",
+            "cotisation_moy12m_latest",
+        ],
+    ),
     Redressement(
         "Redressement URSSAF evolution dette Juillet 2020",
         redressement_urssaf_covid,

--- a/predictsignauxfaibles/redressements.py
+++ b/predictsignauxfaibles/redressements.py
@@ -96,7 +96,7 @@ def prepare_redressement_urssaf_covid(data: pd.DataFrame):
     latest.data.set_index(["siret", "siren"], inplace=True)
     july2020.data.set_index(["siret", "siren"], inplace=True)
 
-    data = data.join(july2020, rsuffix="_july2020")
-    data = data.join(latest, lsuffix="_july2020", rsuffix="latest")
+    data = data.join(july2020.data, rsuffix="_july2020")
+    data = data.join(latest.data, lsuffix="_july2020", rsuffix="latest")
 
     return data

--- a/predictsignauxfaibles/redressements.py
+++ b/predictsignauxfaibles/redressements.py
@@ -97,6 +97,6 @@ def prepare_redressement_urssaf_covid(data: pd.DataFrame):
     july2020.data.set_index(["siret", "siren"], inplace=True)
 
     data = data.join(july2020.data, rsuffix="_july2020")
-    data = data.join(latest.data, lsuffix="_july2020", rsuffix="latest")
+    data = data.join(latest.data, lsuffix="_july2020", rsuffix="_latest")
 
     return data


### PR DESCRIPTION
As discussed yesterday, this PR adds a "preparation" step to the redressement pipeline
- fetch latest and july 2020 data
- join these data to the main dataset, thus creating the columns needed to run `redressement_urssaf_covid`

Still todo : add redressements step to CLI