### PR TITLE
fix: paydex variables are grouped only if they exist

### DIFF
--- a/predictsignauxfaibles/explain.py
+++ b/predictsignauxfaibles/explain.py
@@ -107,7 +107,8 @@ def explain(
 
     macro_prod = micro_prod.groupby(by="Group", axis=1).sum()
 
-    micro_prod = group_retards_paiement(micro_prod, macro_prod, multi_columns_full)
+    if "retards_paiement" in conf.FEATURE_GROUPS.keys():
+        micro_prod = group_retards_paiement(micro_prod, macro_prod, multi_columns_full)
 
     micro_select_concerning = micro_prod.apply(
         lambda s: list_concerning_contributions(s, thr=thresh_micro), axis=1
@@ -155,7 +156,8 @@ def explain(
     )
 
     macro_expl = micro_expl.groupby(by="Group", axis=1).sum()
-    micro_expl = group_retards_paiement(micro_expl, macro_expl, multi_columns_full)
+    if "retards_paiement" in conf.FEATURE_GROUPS.keys():
+        micro_expl = group_retards_paiement(micro_expl, macro_expl, multi_columns_full)
 
     # Aggregating contributions at the group level
     sf_data.data["macro_expl"] = macro_expl.apply(lambda x: x.to_dict(), axis=1)


### PR DESCRIPTION
This is a fix to `predictsignauxfaibles.explain`function `explain`, which attempts to replace the contribution of micro features from group `retards_paiement` with the aggregated contribution, so as to have a single variable `retards_paiement` as an explanation for the contribution of variables coming from Altares.

The function used to attempt this aggregation whether or not the features from `retards_paiement` existed.
Here we just check that they exist before aggregation.

In the long run, we should create a dictionary of micro variables to group, so as to make generic both function `group_retards_paiement` and the condition in this fix. 