### PR TITLE
fix: DataFrame objects built in `explain` now use same index as input

### DIFF
--- a/predictsignauxfaibles/explain.py
+++ b/predictsignauxfaibles/explain.py
@@ -98,9 +98,11 @@ def explain(
     ## ------------------------------------------------------
     feats_contr = np.multiply(coefs, unraveled_data)
 
-    micro_prod = pd.DataFrame(feats_contr, columns=multi_columns_full).drop(
-        [("model_offset", "model_offset")], axis=1, inplace=False
-    )
+    micro_prod = pd.DataFrame(
+        feats_contr,
+        columns=multi_columns_full,
+        index=sf_data.data.index,
+    ).drop([("model_offset", "model_offset")], axis=1, inplace=False)
     micro_prod.columns = pd.MultiIndex.from_tuples(
         micro_prod.columns, names=["Group", "Feature"]
     )
@@ -128,6 +130,7 @@ def explain(
     micro_radar = pd.DataFrame(
         offset_feats_contr,
         columns=multi_columns_full,
+        index=sf_data.data.index,
     ).drop([("model_offset", "model_offset")], axis=1, inplace=False)
     micro_radar.columns = pd.MultiIndex.from_tuples(
         micro_radar.columns, names=["Group", "Feature"]
@@ -149,6 +152,7 @@ def explain(
     micro_expl = pd.DataFrame(
         norm_feats_contr,
         columns=multi_columns_full,
+        index=sf_data.data.index,
     )
     micro_expl.columns = pd.MultiIndex.from_tuples(
         micro_expl.columns, names=["Group", "Feature"]


### PR DESCRIPTION
In function `explain`, the various `pandas.DataFrames` that are created and used to build new columns use a natural, contiguous Index.
As of June 2nd 2021, we still use an index for input sf_data that can be non-contiguous, for instance because some SIRETs are removed from the dataset when there is missing data for those SIRETs.
For this reason, a `sf_data.data[new_field_name] = new_series` would result in a critical misalignment of data, which can be very dangerous.

Altough a fix will be introduced in `predictsignauxfaibles` to make indexing contiguous by default, this fix forces the index of new DataFrames that are built in function `explain` to use the index from the original DataFrame, which solves the issue.
Note that using `pd.merge` in this function may also solve the issue, but would make such a function heavier, thus we find a way to use direct slice copy instead