### PR TITLE
fix: pad siret/siren with zeros on the left

### DIFF
--- a/predictsignauxfaibles/data.py
+++ b/predictsignauxfaibles/data.py
@@ -154,8 +154,12 @@ class SFDataset:
         # force SIREN and SIRET to be strings
         if "siren" in self.data.columns:
             self.data.siren = self.data.siren.astype(str)
+            # pad with zeroes
+            self.data.siren = self.data.siren.apply(lambda s: s.zfill(9))
         if "siret" in self.data.columns:
             self.data.siret = self.data.siret.astype(str)
+            # pad with zeroes
+            self.data.siret = self.data.siret.apply(lambda s: s.zfill(14))
 
         return self
 


### PR DESCRIPTION
This quick PR builds on #68 and makes sure that resulting siret and siren are the right length

```python
>>> "1234567".zfill(9)
'001234567'
>>> "123456789123".zfill(14)
'00123456789123'
```